### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ pip install django-cors-headers
 
 1. 首先 `clone` 代码到服务器。
 2. 构建镜像，拉取镜像 `docker pull xueyikang/stealer:1.0.0` <br/>
+   给拉取的镜像打tag  `docker tag xueyikang/stealer:1.0.0 stealer-1.0.0 ` <br/>
 或切换文件夹 `cd stealer` 然后执行命令 `docker build -t stealer-1.0.0 -f Dockerfile .` 即可生成镜像文件。
 3. 启动容器，执行命令 `docker run -d -p 8000:8000 stealer-1.0.0:latest`
 4. 应用地址为： 服务器IP:8000


### PR DESCRIPTION
docker启动方式的文档 第二步拉取镜像后要打tag 不然第三步找不到对应的镜像

docker run -d -p 8000:8000 stealer-1.0.0:latest

Unable to find image 'stealer-1.0.0:latest' locally